### PR TITLE
hiclass 4.11.0 :snowflake:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,9 @@ requirements:
     #- shap ==0.44.1      # we have skipped this version
     #- xarray ==2023.1.0  # we have 2023.6.0
 
+# WARNING: these tests include connections to zenodo.org (a CERN
+# dataset sharing site).  Not all CI workers can connect.
+
 # We don't have pyfakefs
 {% set tests_to_ignore = " --ignore=tests/test_LocalClassifiers.py" %}
 
@@ -41,6 +44,11 @@ requirements:
 # We don't have xr
 {% set tests_to_skip = tests_to_skip + "test_explainer_tree_lcppn" %}
 {% set tests_to_skip = tests_to_skip + " or test_explainer_tree_lcpl" %}
+
+# connection failures
+{% set tests_to_skip = tests_to_skip + " or test_load_hierarchical_text_classification_shape" %}        # [osx]
+{% set tests_to_skip = tests_to_skip + " or test_load_hierarchical_text_classification_random_state" %} # [osx]
+{% set tests_to_skip = tests_to_skip + " or test_load_hierarchical_text_classification_file_exists" %}  # [osx]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,13 +34,28 @@ requirements:
     #- shap ==0.44.1      # we have skipped this version
     #- xarray ==2023.1.0  # we have 2023.6.0
 
+# We don't have pyfakefs
+{% set tests_to_ignore = " --ignore=tests/test_LocalClassifiers.py" %}
+
+{% set tests_to_skip = "" %}
+# We don't have xr
+{% set tests_to_skip = tests_to_skip + "test_explainer_tree_lcppn" %}
+{% set tests_to_skip = tests_to_skip + " or test_explainer_tree_lcpl" %}
+
 test:
+  source_files:
+    - tests
   imports:
     - hiclass
   requires:
     - pip
+    - pytest
+    - requests
+    - pandas
+    - shap
   commands:
     - pip check
+    - pytest -v tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://github.com/scikit-learn-contrib/hiclass

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,11 @@ requirements:
 # WARNING: these tests include connections to zenodo.org (a CERN
 # dataset sharing site).  Not all CI workers can connect.
 
+{% set tests_to_ignore = "" %}
 # We don't have pyfakefs
-{% set tests_to_ignore = " --ignore=tests/test_LocalClassifiers.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/test_LocalClassifiers.py" %}
+# s390x doesn't have shap
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/test_Explainer.py" %}
 
 {% set tests_to_skip = "" %}
 # We don't have xr
@@ -50,6 +53,10 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_load_hierarchical_text_classification_random_state" %} # [osx]
 {% set tests_to_skip = tests_to_skip + " or test_load_hierarchical_text_classification_file_exists" %}  # [osx]
 
+# $PREFIX/bin/python -sS -c 'import platform; print(platform.mac_ver()[0])' failes
+{% set tests_to_skip = tests_to_skip + " or test_fit_digraph" %}  # [osx and x86_64]
+
+
 test:
   source_files:
     - tests
@@ -60,7 +67,7 @@ test:
     - pytest
     - requests
     - pandas
-    - shap
+    - shap  # [not s390x]
   commands:
     - pip check
     - pytest -v tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
 # We don't have pyfakefs
 {% set tests_to_ignore = tests_to_ignore + " --ignore=tests/test_LocalClassifiers.py" %}
 # s390x doesn't have shap
-{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/test_Explainer.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/test_Explainer.py" %}  # [s390x]
 
 {% set tests_to_skip = "" %}
 # We don't have xr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,8 @@ requirements:
 
 # $PREFIX/bin/python -sS -c 'import platform; print(platform.mac_ver()[0])' failes
 {% set tests_to_skip = tests_to_skip + " or test_fit_digraph" %}  # [osx and x86_64]
+{% set tests_to_skip = tests_to_skip + " or test_fit_1_class" %}  # [osx and x86_64]
+{% set tests_to_skip = tests_to_skip + " or test_fit_1_label" %}  # [osx and x86_64]
 
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,22 +10,29 @@ source:
   sha256: e8a465824133ead5e2552f36bce558418305b4d81b233f605bb97cdc5d8d22c5
 
 build:
-  noarch: python
+  skip: True  # [py<38 or py>311]
   number: 0
   entry_points:
     - hiclass = hiclass.__main__:main
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.7,<3.9
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.7,<3.9
+    - python
     - networkx
-    - numpy <1.24
-    - scikit-learn
-    - ray-core
+    - numpy
+    - scikit-learn <1.5
+    - scipy <1.13
+  run_constrained:
+    - ray-core >=1.11.0
+    # xai wants the following specific versions
+    #- shap ==0.44.1      # we have skipped this version
+    #- xarray ==2023.1.0  # we have 2023.6.0
 
 test:
   imports:


### PR DESCRIPTION
hiclass 4.11.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5598]
- dev_url:        https://github.com/scikit-learn-contrib/hiclass/tree/v4.11.0
- conda_forge:    https://github.com/conda-forge/hiclass-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/hiclass/4.11.0
- pypi inspector: https://inspector.pypi.io/project/hiclass/4.11.0

### Explanation of changes:

- fork conda-forge
- tweaks:
  - `.gitignore` to allow `abs.yaml`
  - update deps
    - push `ray-core` into `run_constrained`
- add upstream tests
  - **WARNING** these include connections to https://zenodo.org (a CERN dataset sharing site) -- not all CI workers can connect


[PKG-5598]: https://anaconda.atlassian.net/browse/PKG-5598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ